### PR TITLE
feat: Add board archiving, comment edit/delete, and Google avatar sync

### DIFF
--- a/src/routes/famban/API_DOCUMENTATION.md
+++ b/src/routes/famban/API_DOCUMENTATION.md
@@ -63,6 +63,8 @@ Each resource folder is self-contained: `<resource>.js` is the Express router, `
 - POST /kanban/cards/:id/assign
 - POST /kanban/cards/:id/tags
 - POST /kanban/cards/:id/comments
+- PATCH /kanban/cards/:id/comments/:commentId
+- DELETE /kanban/cards/:id/comments/:commentId
 
 ---
 
@@ -73,6 +75,7 @@ MongoDB (the shared client from `src/database/mongo.js`, database `milloy-dev`).
 - `famban-users`:
   - `name` (string, required)
   - `email` (string or null) - sparse unique index; join key for Google sign-in (see "Authentication" below) - must be set and `active: true` for that email to be able to log in
+  - `avatarUrl` (string or null) - the account's Google profile photo URL, populated/refreshed from the ID token's `picture` claim on every `POST /auth/google` login (see "Authentication" below). `null` until the first login, and for family members created via `POST /users` who've never signed in.
   - `active` (bool, required)
   - `createdAt`, `updatedAt` (date, required)
 
@@ -86,6 +89,8 @@ MongoDB (the shared client from `src/database/mongo.js`, database `milloy-dev`).
   - `description` (string or null)
   - `columns` (array, required) - `[{ id, name, order, kind }]`, ids are UUIDs generated server-side
     - `kind` (enum: `todo` | `in_progress` | `done` | `null`, optional) - marks a column as structurally managed by card `status` (see "Column kinds" below). Boards created before this field existed have no `kind` on any column and are left as-is (see "Implementation notes").
+  - `archived` (bool, required) - soft-delete flag (see "Archiving boards" below). Boards created before this field existed were backfilled to `archived: false` at startup (`database.js`), unlike the `kind` backfill gap above - there is no "legacy boards" caveat for this one.
+  - `archivedAt` (date or null) - set/cleared alongside `archived`, same shape as `doneAt`/`closedAt` on cards
   - `createdAt`, `updatedAt` (date, required)
 
 - `famban-cards`:
@@ -95,7 +100,8 @@ MongoDB (the shared client from `src/database/mongo.js`, database `milloy-dev`).
   - `assignees` (ObjectId[], required) - references `famban-users`
   - `tags` (ObjectId[], required) - references `famban-tags`
   - `order` (int, required) - position within its column
-  - `comments` (array, required) - `[{ id, userId, text, createdAt }]`, embedded
+  - `comments` (array, required) - `[{ id, userId, text, createdAt, editedAt }]`, embedded
+    - `editedAt` (date or null, required) - set when the comment's author edits its `text` via `PATCH .../comments/:commentId`, `null` until then. Comments predating this field were backfilled to `editedAt: null` at startup (`database.js`), same approach as `archived` on boards.
   - `doneAt`, `closedAt` (date or null) - set/cleared by status transitions
   - `createdAt`, `updatedAt` (date, required)
 
@@ -111,12 +117,13 @@ Indexes: `famban-users.email` (unique, sparse), `famban-tags.name` (unique, case
 - Common error codes:
   - `INVALID_ID` (400) - malformed ObjectId in a path/query param
   - `USER_NAME_REQUIRED` / `TAG_NAME_REQUIRED` / `BOARD_NAME_REQUIRED` / `CARD_TITLE_REQUIRED` / `COLUMN_NAME_REQUIRED` / `COMMENT_TEXT_REQUIRED` (400)
-  - `USER_NOT_FOUND` / `TAG_NOT_FOUND` / `BOARD_NOT_FOUND` / `CARD_NOT_FOUND` / `COLUMN_NOT_FOUND` (404)
+  - `USER_NOT_FOUND` / `TAG_NOT_FOUND` / `BOARD_NOT_FOUND` / `CARD_NOT_FOUND` / `COLUMN_NOT_FOUND` / `COMMENT_NOT_FOUND` (404)
   - `USER_ALREADY_EXISTS` / `TAG_ALREADY_EXISTS` (409) - duplicate email/name
   - `INVALID_TAG_COLOR` (400) - color isn't a `#rrggbb` hex string
   - `INVALID_ASSIGNEES` / `INVALID_TAGS` (400) - one or more referenced ids don't exist
   - `INVALID_STATUS` (400) - status isn't `open`/`in_progress`/`done`/`closed`
   - `INVALID_ORDER` (400) - `order` isn't an integer
+  - `COMMENT_NOT_OWNER` (403) - tried to edit or delete a comment posted by a different family member (or one with no author at all)
   - `COLUMN_NOT_EMPTY` (409) - tried to delete a column that still has cards on it
   - `COLUMN_KIND_PROTECTED` (400) - tried to delete a `todo`/`in_progress`/`done` kinded column; only plain (`kind: null`) columns can be deleted
   - `COLUMN_STATUS_MANAGED` (400) - tried to create or move a card directly into an `in_progress` or `done` kinded column; those are only reachable via `POST /kanban/cards/:id/status`
@@ -130,9 +137,9 @@ Authentication:
 
 - **Every** route - reads included - requires a session, via `requireSession`. This is a private family app, not a public read surface.
 - Sessions are obtained by `POST /auth/google` (see below) and carried as `Authorization: Bearer <token>` on every subsequent request. There are no cookies involved.
-- The session is a stateless JWT (`FAMBAN_SESSION_SECRET`, 7 day expiry) containing `{ userId, email, name }`. It can't be revoked before it expires short of rotating the secret (which invalidates every session at once) - acceptable for a two-person household app, revisit if that changes.
+- The session is a stateless JWT (`FAMBAN_SESSION_SECRET`, 7 day expiry) containing `{ userId, email, name, avatarUrl }`. It can't be revoked before it expires short of rotating the secret (which invalidates every session at once) - acceptable for a two-person household app, revisit if that changes. `avatarUrl` is a snapshot taken at login time - if it changes on Google's side mid-session, the session JWT won't reflect that until the next login (`GET /users` always has the current value, since it reads the database directly).
 - Login itself is gated by two independent allowlists: Google's OAuth consent screen is left in **Testing** mode with an explicit test-user list (Google rejects anyone else before your code runs at all), and the backend separately requires the email to match an `active: true` `famban-users` record (no auto-provisioning from an arbitrary Google login). Adding a new family member means creating their `famban-users` row first (via `POST /users`, or `scripts/seedFambanUsers.js` for the very first account) _and_ adding them as a Google test user.
-- Route handlers read the authenticated identity off `req.fambanUser` (set by `requireSession`) rather than trusting client-supplied ids - e.g. `POST /kanban/cards/:id/comments` ignores any `userId` in the request body and always attributes the comment to the logged-in caller.
+- Route handlers read the authenticated identity off `req.fambanUser` (set by `requireSession`) rather than trusting client-supplied ids - e.g. `POST /kanban/cards/:id/comments` ignores any `userId` in the request body and always attributes the comment to the logged-in caller. The same identity is used to authorize `PATCH`/`DELETE /kanban/cards/:id/comments/:commentId` - a caller can only edit or delete a comment whose stored `userId` matches their own session `userId`, never a value from the request body.
 
 Rate limiting:
 
@@ -147,7 +154,7 @@ Rate limiting:
 
 ### 1) POST /auth/google
 
-- Description: Exchange a Google ID token for a Famban session. Not gated by `requireSession` - this is how a session gets created in the first place.
+- Description: Exchange a Google ID token for a Famban session. Not gated by `requireSession` - this is how a session gets created in the first place. Also refreshes the user's stored `avatarUrl` from the token's `picture` claim if it's changed since the last login (see "Authentication" below).
 - Request body: `credential` (string, required) - the ID token returned by Google Identity Services' "Sign in with Google" button on the frontend.
 - Successful response: 200, returns `{ token, user }` - the client stores `token` and sends it as `Authorization: Bearer <token>` on every subsequent request.
 
@@ -162,7 +169,8 @@ Rate limiting:
   "user": {
     "_id": "6a6fb751f319991a0322aafb",
     "name": "Connor",
-    "email": "connor@example.com"
+    "email": "connor@example.com",
+    "avatarUrl": "https://lh3.googleusercontent.com/a/photo-url"
   }
 }
 ```
@@ -182,6 +190,7 @@ Errors: `GOOGLE_CREDENTIAL_REQUIRED` (400), `INVALID_GOOGLE_CREDENTIAL` / `GOOGL
     "userId": "6a6fb751f319991a0322aafb",
     "email": "connor@example.com",
     "name": "Connor",
+    "avatarUrl": "https://lh3.googleusercontent.com/a/photo-url",
     "iat": 1234567890,
     "exp": 1235172690
   }
@@ -206,6 +215,7 @@ Errors: `GOOGLE_CREDENTIAL_REQUIRED` (400), `INVALID_GOOGLE_CREDENTIAL` / `GOOGL
       "_id": "6a6fb751f319991a0322aafb",
       "name": "Connor",
       "email": "connor@example.com",
+      "avatarUrl": "https://lh3.googleusercontent.com/a/photo-url",
       "active": true,
       "createdAt": "2026-08-02T21:32:01.384Z",
       "updatedAt": "2026-08-02T21:32:01.384Z"
@@ -308,7 +318,8 @@ Errors: `INVALID_ID` (400), `TAG_NOT_FOUND` (404).
 
 ### 10) GET /kanban/boards
 
-- Description: List all boards.
+- Description: List boards. Archived boards are excluded by default.
+- Query parameters (optional): `includeArchived` (`true` to include archived boards alongside active ones; anything else, or omitted, excludes them) - no separate "browse archived boards" surface exists, this is the same list with the filter lifted.
 - Authentication: Requires a session (`Authorization: Bearer <token>`).
 - Rate limiting: `fambanRateLimiter`
 
@@ -316,7 +327,7 @@ Errors: `INVALID_ID` (400), `TAG_NOT_FOUND` (404).
 
 ### 11) GET /kanban/boards/:id
 
-- Description: Get a single board, including its columns.
+- Description: Get a single board, including its columns. Works the same whether the board is archived or not - archiving only affects `GET /kanban/boards` (the list). Anyone with a direct link to an archived board (a stale bookmark, a Slack link) can still open it; there's no separate "restricted" state.
 - Authentication: Requires a session (`Authorization: Bearer <token>`).
 
 ```json
@@ -324,6 +335,8 @@ Errors: `INVALID_ID` (400), `TAG_NOT_FOUND` (404).
   "_id": "6a6fb751f319991a0322aafc",
   "name": "Family Board",
   "description": null,
+  "archived": false,
+  "archivedAt": null,
   "columns": [
     {
       "id": "589d7e78-bebf-4348-92e9-12d4f2e94f7e",
@@ -369,9 +382,13 @@ Errors: `BOARD_NAME_REQUIRED`, `COLUMN_NAME_REQUIRED` (400).
 
 ### 13) PATCH /kanban/boards/:id
 
-- Description: Update a board's name/description.
+- Description: Update a board's name/description, or archive/unarchive it. This is also the only way to remove a board from the frontend's board list - there's no dedicated delete endpoint, matching how `PATCH /users/:id` with `{ active: false }` is the only way to remove a user. Cards on the board are completely untouched by archiving - no cascade, no bulk update; they remain fetchable via `GET /kanban/cards?boardId=...` same as before.
 - Authentication: Requires a session (`Authorization: Bearer <token>`).
-- Request body (all optional): `name`, `description`
+- Request body (all optional): `name`, `description`, `archived` (bool - setting `true` stamps `archivedAt`; setting `false` un-archives and clears `archivedAt`. Reversible via the API in either direction - a destructive-feeling "type the board name to confirm" flow is a frontend-only affordance, not something the API enforces as one-way.)
+
+```json
+{ "archived": true }
+```
 
 Errors: `INVALID_ID`, `BOARD_NAME_REQUIRED` (400), `BOARD_NOT_FOUND` (404).
 
@@ -444,7 +461,8 @@ Errors: `INVALID_ID` (400, malformed `boardId`/`assignee`/`tag`), `INVALID_STATU
       "id": "5a95f31b-a3e6-409c-99cf-42f70fcbc2b1",
       "userId": "6a6fb751f319991a0322aafb",
       "text": "On it",
-      "createdAt": "2026-08-02T21:32:02.087Z"
+      "createdAt": "2026-08-02T21:32:02.087Z",
+      "editedAt": null
     }
   ],
   "doneAt": null,
@@ -534,7 +552,7 @@ Errors: `INVALID_TAGS` (400), `CARD_NOT_FOUND` (404).
 
 ### 24) POST /kanban/cards/:id/comments
 
-- Description: Append a comment to a card. `userId` is taken from the caller's session, not the request body - you cannot attribute a comment to anyone but yourself.
+- Description: Append a comment to a card. `userId` is taken from the caller's session, not the request body - you cannot attribute a comment to anyone but yourself. `createdAt` is stamped server-side; `editedAt` starts `null`.
 - Authentication: Requires a session (`Authorization: Bearer <token>`).
 - Request body: `text` (string, required)
 - Successful response: 201, returns the full updated card
@@ -544,6 +562,31 @@ Errors: `INVALID_TAGS` (400), `CARD_NOT_FOUND` (404).
 ```
 
 Errors: `COMMENT_TEXT_REQUIRED` (400), `CARD_NOT_FOUND` (404).
+
+---
+
+### 25) PATCH /kanban/cards/:id/comments/:commentId
+
+- Description: Edit a comment's text. Only the family member who originally posted it can edit it - the caller's session identity is compared against the comment's stored `userId` (there's no `userId` in the request body to spoof). Stamps `editedAt` on the comment and bumps the card's `updatedAt`.
+- Authentication: Requires a session (`Authorization: Bearer <token>`).
+- Request body: `text` (string, required)
+- Successful response: 200, returns the full updated card
+
+```json
+{ "text": "Updated text" }
+```
+
+Errors: `COMMENT_TEXT_REQUIRED` (400), `CARD_NOT_FOUND` / `COMMENT_NOT_FOUND` (404), `COMMENT_NOT_OWNER` (403).
+
+---
+
+### 26) DELETE /kanban/cards/:id/comments/:commentId
+
+- Description: Delete a comment. Same ownership rule as editing - only the original author can delete their own comment. Unlike cards themselves (no delete, only status transitions), comments do support a real delete: they're throwaway remarks, not the thing the "preserve history" design note is protecting.
+- Authentication: Requires a session (`Authorization: Bearer <token>`).
+- Successful response: 200, returns the full updated card
+
+Errors: `CARD_NOT_FOUND` / `COMMENT_NOT_FOUND` (404), `COMMENT_NOT_OWNER` (403).
 
 ---
 
@@ -572,8 +615,27 @@ The coupling only runs one direction, and only for the two managed non-todo kind
 - Reopening a card (any status back to `open`) always sends it to the `todo` column, not back to wherever it was before it advanced - there's no position history kept.
 
 **Legacy boards**: boards created before this field existed have `kind: null` on every column (no migration was run - see `boards.schema.js` history if you need the exact cutover point). For those boards, `POST /kanban/cards/:id/status` still updates `status`/`doneAt`/`closedAt` normally, but since there's no `in_progress`/`done`-kind column to move a card *to*, `columnId` is left untouched - i.e. `status` and `columnId` remain fully independent on those boards, exactly like before this feature. Frontend code that still wants a "Done" grouping for a legacy board has no structural signal to key off (`kind` is `null` everywhere) and must keep whatever it was doing before.
-- There's no card delete endpoint, only status transitions (`close`/`reopen`) - this preserves history. Revisit if that turns out to be wrong.
-- There's no board delete endpoint either (only column add/rename/delete within a board). Deleting a whole board isn't currently possible via the API.
+- There's no card delete endpoint, only status transitions (`close`/`reopen`) - this preserves history. Revisit if that turns out to be wrong. Comments are the one exception - see "Comments" below.
+- There's still no hard-delete board endpoint, and none is planned - "deleting" a board from the frontend means `PATCH /kanban/boards/:id` with `{ archived: true }` (see "Archiving boards" below). Column add/rename/delete within a board is unaffected by this and unrelated to it.
 - There's no hard-delete for users - `PATCH /users/:id` with `{ active: false }` is the only removal mechanism, and an inactive user can no longer log in (see `loginWithGoogle`) but their historical assignments/comments remain intact.
+
+## Archiving boards
+
+`PATCH /kanban/boards/:id` with `{ archived: true }` is the frontend's "delete a board" - it's how the product's board-removal flow (a destructive-looking "type the board name to confirm" UI) is implemented under the hood, deliberately extending this API's existing soft-delete convention (cards use status transitions, users use `active: false`) rather than introducing the system's first hard delete.
+
+- Setting `archived: true` stamps `archivedAt`; setting `archived: false` clears it. Both directions are valid at the API level - the flow is only "one-way" as a matter of frontend UX (no unarchive button is currently planned), not an API restriction. A future admin surface could unarchive a board with the exact same `PATCH` call.
+- `GET /kanban/boards` excludes archived boards by default. Pass `?includeArchived=true` to get the full list including archived ones - there's no separate endpoint or way to list *only* archived boards; a caller wanting that filters client-side.
+- `GET /kanban/boards/:id` does **not** change behavior for an archived board - it returns normally, same as any other board. Archiving only affects whether a board shows up in the list; a board's direct URL/id keeps working exactly as before. This also means nothing needed to change in `getBoardById`, which every other board/card operation is built on.
+- Cards are completely unaffected by archiving a board - no cascade, no bulk status change, nothing in `famban-cards` reads or writes `archived` at all. `POST /kanban/cards` and `PATCH /kanban/cards/:id` against an archived board's `boardId` still succeed; there is no `COLUMN`/`BOARD`-archived error code. If blocking new cards on an archived board turns out to matter later, that's a deliberate follow-up, not an oversight.
+
+## Comments
+
+Comments carry a real `createdAt` timestamp (stamped on `POST /kanban/cards/:id/comments`) and support a genuine edit/delete, unlike everything else in this API:
+
+- **Edit**: `PATCH /kanban/cards/:id/comments/:commentId` with `{ text }` updates the comment's text and stamps `editedAt`. A comment that's never been edited has `editedAt: null` - the frontend can use that to decide whether to render an "(edited)" marker.
+- **Delete**: `DELETE /kanban/cards/:id/comments/:commentId` removes the comment from the card entirely (`$pull`, not a status flag) - there is no soft-delete, no tombstone, nothing left behind. This is a deliberate exception to the "nothing hard-deletes" convention elsewhere in this API (cards use status transitions, users use `active: false`, boards use `archived`): a comment is a throwaway remark, not the kind of record those other "preserve history" decisions exist to protect.
+- **Ownership**: both endpoints require the caller's session `userId` to match the comment's stored `userId` exactly - you can only edit or delete your own comments, never a family member's. A comment with `userId: null` (possible if authored before session-based attribution, or via direct API access without a resolvable user) can't be edited or deleted by anyone through these endpoints, since there's no author to match against.
+- Both endpoints return the full updated card (same convention as `POST /kanban/cards/:id/comments`), and both bump the card's own `updatedAt`.
+
 - `order` is a plain integer per column, not fractional - reordering N cards in a column means the client may need to PATCH up to N cards' `order` values.
 - Frontend login flow: render Google Identity Services' "Sign in with Google" button with the `GOOGLE_CLIENT_ID`, POST the resulting `credential` to `POST /auth/google`, store the returned `token`, and attach it as `Authorization: Bearer <token>` on every request thereafter. A 401 on any request means the token is missing/expired/invalid - re-run the login flow.

--- a/src/routes/famban/auth/auth.js
+++ b/src/routes/famban/auth/auth.js
@@ -19,6 +19,7 @@ router.post('/google', fambanRateLimiter, async (req, res) => {
         _id: user._id,
         name: user.name,
         email: user.email,
+        avatarUrl: user.avatarUrl || null,
       },
     });
   } catch (err) {

--- a/src/routes/famban/auth/auth.routes.test.js
+++ b/src/routes/famban/auth/auth.routes.test.js
@@ -29,7 +29,12 @@ describe('auth router', () => {
   test('POST /auth/google forwards the credential and returns a token + user', async () => {
     authService.loginWithGoogle.mockResolvedValue({
       token: 'signed-token',
-      user: { _id: '1', name: 'Connor', email: 'connor@example.com' },
+      user: {
+        _id: '1',
+        name: 'Connor',
+        email: 'connor@example.com',
+        avatarUrl: 'https://lh3.googleusercontent.com/a/photo',
+      },
     });
 
     const res = await request(buildApp())
@@ -41,8 +46,26 @@ describe('auth router', () => {
     expect(res.body).toEqual({
       message: 'Logged in successfully',
       token: 'signed-token',
+      user: {
+        _id: '1',
+        name: 'Connor',
+        email: 'connor@example.com',
+        avatarUrl: 'https://lh3.googleusercontent.com/a/photo',
+      },
+    });
+  });
+
+  test('POST /auth/google defaults avatarUrl to null when the service returns none', async () => {
+    authService.loginWithGoogle.mockResolvedValue({
+      token: 'signed-token',
       user: { _id: '1', name: 'Connor', email: 'connor@example.com' },
     });
+
+    const res = await request(buildApp())
+      .post('/api/famban/auth/google')
+      .send({ credential: 'google-id-token' });
+
+    expect(res.body.user.avatarUrl).toBeNull();
   });
 
   test('POST /auth/google translates a service error to its status/code', async () => {

--- a/src/routes/famban/auth/auth.service.js
+++ b/src/routes/famban/auth/auth.service.js
@@ -78,10 +78,22 @@ async function loginWithGoogle(idToken) {
     );
   }
 
+  // Keep the stored avatar in sync with Google on every login, so a
+  // changed profile photo shows up without any dedicated update flow.
+  const avatarUrl = payload.picture || null;
+  if (avatarUrl !== (user.avatarUrl || null)) {
+    await usersCollection().updateOne(
+      { _id: user._id },
+      { $set: { avatarUrl, updatedAt: new Date() } }
+    );
+    user.avatarUrl = avatarUrl;
+  }
+
   const token = createSessionToken({
     userId: user._id.toHexString(),
     email: user.email,
     name: user.name,
+    avatarUrl: user.avatarUrl || null,
   });
 
   return { token, user };

--- a/src/routes/famban/auth/auth.service.test.js
+++ b/src/routes/famban/auth/auth.service.test.js
@@ -123,5 +123,56 @@ describe('auth.service', () => {
       expect(result.user).toEqual(user);
       expect(typeof result.token).toBe('string');
     });
+
+    test('backfills avatarUrl from the Google payload when it differs from the stored value', async () => {
+      const user = {
+        _id: new ObjectId(),
+        name: 'Connor',
+        email: 'connor@example.com',
+        avatarUrl: null,
+      };
+      verifyIdToken.mockResolvedValue({
+        getPayload: () => ({
+          email: 'connor@example.com',
+          email_verified: true,
+          picture: 'https://lh3.googleusercontent.com/a/new-photo',
+        }),
+      });
+      usersCollection.findOne.mockResolvedValue(user);
+
+      const result = await loginWithGoogle('token');
+
+      expect(usersCollection.updateOne).toHaveBeenCalledWith(
+        { _id: user._id },
+        {
+          $set: {
+            avatarUrl: 'https://lh3.googleusercontent.com/a/new-photo',
+            updatedAt: expect.any(Date),
+          },
+        }
+      );
+      expect(result.user.avatarUrl).toBe(
+        'https://lh3.googleusercontent.com/a/new-photo'
+      );
+    });
+
+    test('does not write when the Google payload has no picture and none is stored', async () => {
+      const user = {
+        _id: new ObjectId(),
+        name: 'Connor',
+        email: 'connor@example.com',
+      };
+      verifyIdToken.mockResolvedValue({
+        getPayload: () => ({
+          email: 'connor@example.com',
+          email_verified: true,
+        }),
+      });
+      usersCollection.findOne.mockResolvedValue(user);
+
+      await loginWithGoogle('token');
+
+      expect(usersCollection.updateOne).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/routes/famban/database.js
+++ b/src/routes/famban/database.js
@@ -27,12 +27,46 @@ async function applyValidator(db, name, validator) {
   }
 }
 
+// One-time backfill for boards created before `archived`/`archivedAt`
+// existed, so a later update to one of them doesn't fail validation by
+// omitting a now-required field. Unlike `kind` on columns, which was left
+// permanently optional for legacy boards, this field is small and cheap
+// enough to backfill outright rather than carry a legacy caveat forever.
+//
+// Must run AFTER the new validator is applied, not before: the old
+// validator still active beforehand has `additionalProperties: false` and
+// doesn't know about `archived`/`archivedAt`, so it would reject this very
+// $set as an unrecognized property and crash startup.
+async function backfillBoardArchivedFields(db) {
+  await db
+    .collection(BOARDS_COLLECTION)
+    .updateMany(
+      { archived: { $exists: false } },
+      { $set: { archived: false, archivedAt: null } }
+    );
+}
+
+// One-time backfill for comments created before `editedAt` existed. Same
+// ordering requirement as backfillBoardArchivedFields above - must run
+// AFTER the new validator is applied, or the still-active old validator's
+// `additionalProperties: false` on each comment subdocument rejects this
+// $set outright.
+async function backfillCommentEditedAtFields(db) {
+  await db.collection(CARDS_COLLECTION).updateMany(
+    { 'comments.editedAt': { $exists: false } },
+    { $set: { 'comments.$[c].editedAt': null } },
+    { arrayFilters: [{ 'c.editedAt': { $exists: false } }] }
+  );
+}
+
 async function initFambanCollections() {
   const db = getDb();
 
   await applyValidator(db, USERS_COLLECTION, usersValidator);
   await applyValidator(db, BOARDS_COLLECTION, boardsValidator);
+  await backfillBoardArchivedFields(db);
   await applyValidator(db, CARDS_COLLECTION, cardsValidator);
+  await backfillCommentEditedAtFields(db);
   await applyValidator(db, TAGS_COLLECTION, tagsValidator);
 
   await db

--- a/src/routes/famban/kanban/boards/boards.js
+++ b/src/routes/famban/kanban/boards/boards.js
@@ -16,7 +16,8 @@ const router = express.Router();
 
 router.get('/', fambanRateLimiter, requireSession, async (req, res) => {
   try {
-    const boards = await listBoards();
+    const includeArchived = req.query.includeArchived === 'true';
+    const boards = await listBoards({ includeArchived });
 
     return res.status(200).json({ count: boards.length, boards });
   } catch (err) {
@@ -49,8 +50,12 @@ router.post('/', fambanRateLimiter, requireSession, async (req, res) => {
 
 router.patch('/:id', fambanRateLimiter, requireSession, async (req, res) => {
   try {
-    const { name, description } = req.body;
-    const board = await updateBoard(req.params.id, { name, description });
+    const { name, description, archived } = req.body;
+    const board = await updateBoard(req.params.id, {
+      name,
+      description,
+      archived,
+    });
 
     return res
       .status(200)

--- a/src/routes/famban/kanban/boards/boards.schema.js
+++ b/src/routes/famban/kanban/boards/boards.schema.js
@@ -2,12 +2,14 @@
 const boardsValidator = {
   $jsonSchema: {
     bsonType: 'object',
-    required: ['name', 'columns', 'createdAt', 'updatedAt'],
+    required: ['name', 'columns', 'archived', 'createdAt', 'updatedAt'],
     additionalProperties: false,
     properties: {
       _id: {},
       name: { bsonType: 'string', minLength: 1 },
       description: { bsonType: ['string', 'null'] },
+      archived: { bsonType: 'bool' },
+      archivedAt: { bsonType: ['date', 'null'] },
       columns: {
         bsonType: 'array',
         items: {

--- a/src/routes/famban/kanban/boards/boards.service.js
+++ b/src/routes/famban/kanban/boards/boards.service.js
@@ -35,8 +35,10 @@ function findColumnByKind(board, kind) {
   return board.columns.find((c) => c.kind === kind) || null;
 }
 
-async function listBoards() {
-  return boardsCollection().find({}).sort({ name: 1 }).toArray();
+async function listBoards({ includeArchived = false } = {}) {
+  const query = includeArchived ? {} : { archived: { $ne: true } };
+
+  return boardsCollection().find(query).sort({ name: 1 }).toArray();
 }
 
 async function getBoardById(id) {
@@ -83,6 +85,8 @@ async function createBoard({ name, description, columns }) {
     name: trimmedName,
     description: description ? String(description).trim() : null,
     columns: [...defaultColumns, ...customColumns],
+    archived: false,
+    archivedAt: null,
     createdAt: now,
     updatedAt: now,
   };
@@ -94,7 +98,8 @@ async function createBoard({ name, description, columns }) {
 async function updateBoard(id, updates) {
   await getBoardById(id);
   const objectId = parseObjectId(id, 'board id');
-  const set = { updatedAt: new Date() };
+  const now = new Date();
+  const set = { updatedAt: now };
 
   if (updates.name !== undefined) {
     const trimmedName = String(updates.name || '').trim();
@@ -114,6 +119,12 @@ async function updateBoard(id, updates) {
     set.description = updates.description
       ? String(updates.description).trim()
       : null;
+  }
+
+  if (updates.archived !== undefined) {
+    const archived = Boolean(updates.archived);
+    set.archived = archived;
+    set.archivedAt = archived ? now : null;
   }
 
   const result = await boardsCollection().findOneAndUpdate(

--- a/src/routes/famban/kanban/boards/boards.service.test.js
+++ b/src/routes/famban/kanban/boards/boards.service.test.js
@@ -42,6 +42,24 @@ describe('boards.service', () => {
 
       await expect(listBoards()).resolves.toEqual(docs);
     });
+
+    test('excludes archived boards by default', async () => {
+      boardsCollection.find.mockReturnValue(createMockCursor([]));
+
+      await listBoards();
+
+      expect(boardsCollection.find).toHaveBeenCalledWith({
+        archived: { $ne: true },
+      });
+    });
+
+    test('includes archived boards when includeArchived is true', async () => {
+      boardsCollection.find.mockReturnValue(createMockCursor([]));
+
+      await listBoards({ includeArchived: true });
+
+      expect(boardsCollection.find).toHaveBeenCalledWith({});
+    });
   });
 
   describe('getBoardById / requireColumn', () => {
@@ -95,6 +113,17 @@ describe('boards.service', () => {
         code: 'BOARD_NAME_REQUIRED',
         status: 400,
       });
+    });
+
+    test('starts unarchived', async () => {
+      boardsCollection.insertOne.mockResolvedValue({
+        insertedId: new ObjectId(),
+      });
+
+      const board = await createBoard({ name: 'Chores' });
+
+      expect(board.archived).toBe(false);
+      expect(board.archivedAt).toBeNull();
     });
 
     test('always seeds To Do / In Progress / Done with matching kinds', async () => {
@@ -165,6 +194,45 @@ describe('boards.service', () => {
       await expect(
         updateBoard(new ObjectId().toHexString(), { name: '  ' })
       ).rejects.toMatchObject({ code: 'BOARD_NAME_REQUIRED' });
+    });
+
+    test('sets archived and stamps archivedAt when archived: true', async () => {
+      const board = { _id: new ObjectId(), name: 'Chores' };
+      boardsCollection.findOne.mockResolvedValue(board);
+      boardsCollection.findOneAndUpdate.mockResolvedValue({
+        ...board,
+        archived: true,
+      });
+
+      await updateBoard(board._id.toHexString(), { archived: true });
+
+      expect(boardsCollection.findOneAndUpdate).toHaveBeenCalledWith(
+        { _id: board._id },
+        {
+          $set: expect.objectContaining({
+            archived: true,
+            archivedAt: expect.any(Date),
+          }),
+        },
+        { returnDocument: 'after' }
+      );
+    });
+
+    test('clears archivedAt when archived: false', async () => {
+      const board = { _id: new ObjectId(), name: 'Chores', archived: true };
+      boardsCollection.findOne.mockResolvedValue(board);
+      boardsCollection.findOneAndUpdate.mockResolvedValue({
+        ...board,
+        archived: false,
+      });
+
+      await updateBoard(board._id.toHexString(), { archived: false });
+
+      expect(boardsCollection.findOneAndUpdate).toHaveBeenCalledWith(
+        { _id: board._id },
+        { $set: expect.objectContaining({ archived: false, archivedAt: null }) },
+        { returnDocument: 'after' }
+      );
     });
   });
 

--- a/src/routes/famban/kanban/cards/cards.js
+++ b/src/routes/famban/kanban/cards/cards.js
@@ -8,6 +8,8 @@ const {
   setCardAssignees,
   setCardTags,
   addComment,
+  editComment,
+  deleteComment,
 } = require('./cards.service');
 const { requireSession } = require('../../shared/requireSession');
 const { sendRouteError } = require('../../shared/errors');
@@ -143,6 +145,48 @@ router.post(
         .json({ message: 'Comment added successfully', card });
     } catch (err) {
       return sendRouteError(res, err, 'Failed to add comment');
+    }
+  }
+);
+
+router.patch(
+  '/:id/comments/:commentId',
+  fambanRateLimiter,
+  requireSession,
+  async (req, res) => {
+    try {
+      const { text } = req.body;
+      const card = await editComment(req.params.id, req.params.commentId, {
+        userId: req.fambanUser.userId,
+        text,
+      });
+
+      return res
+        .status(200)
+        .json({ message: 'Comment updated successfully', card });
+    } catch (err) {
+      return sendRouteError(res, err, 'Failed to update comment');
+    }
+  }
+);
+
+router.delete(
+  '/:id/comments/:commentId',
+  fambanRateLimiter,
+  requireSession,
+  async (req, res) => {
+    try {
+      const card = await deleteComment(
+        req.params.id,
+        req.params.commentId,
+        req.fambanUser.userId
+      );
+
+      return res
+        .status(200)
+        .json({ message: 'Comment deleted successfully', card });
+    } catch (err) {
+      return sendRouteError(res, err, 'Failed to delete comment');
     }
   }
 );

--- a/src/routes/famban/kanban/cards/cards.routes.test.js
+++ b/src/routes/famban/kanban/cards/cards.routes.test.js
@@ -59,6 +59,8 @@ describe('cards router', () => {
     ['post', `/api/famban/kanban/cards/${cardId}/assign`],
     ['post', `/api/famban/kanban/cards/${cardId}/tags`],
     ['post', `/api/famban/kanban/cards/${cardId}/comments`],
+    ['patch', `/api/famban/kanban/cards/${cardId}/comments/comment-1`],
+    ['delete', `/api/famban/kanban/cards/${cardId}/comments/comment-1`],
   ])('%s %s rejects requests without a session', async (method, path) => {
     const res = await request(buildApp())[method](path).send({});
 
@@ -107,6 +109,54 @@ describe('cards router', () => {
     expect(cardsService.addComment).toHaveBeenCalledWith(cardId, {
       userId: sessionUserId,
       text: 'On it',
+    });
+  });
+
+  test('PATCH /cards/:id/comments/:commentId uses the session identity for userId, ignoring any client-supplied value', async () => {
+    cardsService.editComment.mockResolvedValue({ _id: cardId, comments: [] });
+
+    const res = await request(buildApp())
+      .patch(`/api/famban/kanban/cards/${cardId}/comments/comment-1`)
+      .set('Authorization', authHeader)
+      .send({ userId: 'attacker-supplied-id', text: 'Updated' });
+
+    expect(res.status).toBe(200);
+    expect(cardsService.editComment).toHaveBeenCalledWith(
+      cardId,
+      'comment-1',
+      { userId: sessionUserId, text: 'Updated' }
+    );
+  });
+
+  test('DELETE /cards/:id/comments/:commentId uses the session identity for userId', async () => {
+    cardsService.deleteComment.mockResolvedValue({ _id: cardId, comments: [] });
+
+    const res = await request(buildApp())
+      .delete(`/api/famban/kanban/cards/${cardId}/comments/comment-1`)
+      .set('Authorization', authHeader);
+
+    expect(res.status).toBe(200);
+    expect(cardsService.deleteComment).toHaveBeenCalledWith(
+      cardId,
+      'comment-1',
+      sessionUserId
+    );
+  });
+
+  test('a COMMENT_NOT_OWNER error from the service becomes a 403', async () => {
+    const err = new Error('You can only edit or delete your own comments');
+    err.code = 'COMMENT_NOT_OWNER';
+    err.status = 403;
+    cardsService.deleteComment.mockRejectedValue(err);
+
+    const res = await request(buildApp())
+      .delete(`/api/famban/kanban/cards/${cardId}/comments/comment-1`)
+      .set('Authorization', authHeader);
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({
+      error: 'COMMENT_NOT_OWNER',
+      message: 'You can only edit or delete your own comments',
     });
   });
 

--- a/src/routes/famban/kanban/cards/cards.schema.js
+++ b/src/routes/famban/kanban/cards/cards.schema.js
@@ -29,13 +29,14 @@ const cardsValidator = {
         bsonType: 'array',
         items: {
           bsonType: 'object',
-          required: ['id', 'text', 'createdAt'],
+          required: ['id', 'text', 'createdAt', 'editedAt'],
           additionalProperties: false,
           properties: {
             id: { bsonType: 'string' },
             userId: { bsonType: ['objectId', 'null'] },
             text: { bsonType: 'string', minLength: 1 },
             createdAt: { bsonType: 'date' },
+            editedAt: { bsonType: ['date', 'null'] },
           },
         },
       },

--- a/src/routes/famban/kanban/cards/cards.service.js
+++ b/src/routes/famban/kanban/cards/cards.service.js
@@ -274,11 +274,80 @@ async function addComment(id, { userId, text }) {
     userId: resolvedUserId,
     text: trimmedText,
     createdAt: new Date(),
+    editedAt: null,
   };
 
   const result = await cardsCollection().findOneAndUpdate(
     { _id: card._id },
     { $push: { comments: comment }, $set: { updatedAt: new Date() } },
+    { returnDocument: 'after' }
+  );
+
+  return result;
+}
+
+// Throws if `commentId` isn't a real comment on `card`. Returns the comment.
+function requireComment(card, commentId) {
+  const comment = card.comments.find((c) => c.id === commentId);
+
+  if (!comment) {
+    throw createAppError('Comment not found', 'COMMENT_NOT_FOUND', 404);
+  }
+
+  return comment;
+}
+
+// Only the family member who posted a comment may edit or delete it - a
+// comment with no author (userId null, e.g. one predating session-based
+// attribution) can't be claimed by anyone.
+function assertCommentOwner(comment, userId) {
+  if (!comment.userId || String(comment.userId) !== String(userId)) {
+    throw createAppError(
+      'You can only edit or delete your own comments',
+      'COMMENT_NOT_OWNER',
+      403
+    );
+  }
+}
+
+async function editComment(id, commentId, { userId, text }) {
+  const trimmedText = String(text || '').trim();
+
+  if (!trimmedText) {
+    throw createAppError(
+      'Comment text is required',
+      'COMMENT_TEXT_REQUIRED',
+      400
+    );
+  }
+
+  const card = await getCardById(id);
+  const comment = requireComment(card, commentId);
+  assertCommentOwner(comment, userId);
+
+  const result = await cardsCollection().findOneAndUpdate(
+    { _id: card._id, 'comments.id': commentId },
+    {
+      $set: {
+        'comments.$.text': trimmedText,
+        'comments.$.editedAt': new Date(),
+        updatedAt: new Date(),
+      },
+    },
+    { returnDocument: 'after' }
+  );
+
+  return result;
+}
+
+async function deleteComment(id, commentId, userId) {
+  const card = await getCardById(id);
+  const comment = requireComment(card, commentId);
+  assertCommentOwner(comment, userId);
+
+  const result = await cardsCollection().findOneAndUpdate(
+    { _id: card._id },
+    { $pull: { comments: { id: commentId } }, $set: { updatedAt: new Date() } },
     { returnDocument: 'after' }
   );
 
@@ -295,4 +364,6 @@ module.exports = {
   setCardAssignees,
   setCardTags,
   addComment,
+  editComment,
+  deleteComment,
 };

--- a/src/routes/famban/kanban/cards/cards.service.test.js
+++ b/src/routes/famban/kanban/cards/cards.service.test.js
@@ -27,6 +27,8 @@ const {
   setCardAssignees,
   setCardTags,
   addComment,
+  editComment,
+  deleteComment,
 } = require('./cards.service');
 
 describe('cards.service', () => {
@@ -418,6 +420,130 @@ describe('cards.service', () => {
       expect(resolveUserIds).not.toHaveBeenCalled();
       const [, update] = cardsCollection.findOneAndUpdate.mock.calls[0];
       expect(update.$push.comments.userId).toBeNull();
+    });
+
+    test('starts with editedAt null', async () => {
+      await addComment(card._id.toHexString(), { text: 'On it' });
+
+      const [, update] = cardsCollection.findOneAndUpdate.mock.calls[0];
+      expect(update.$push.comments.editedAt).toBeNull();
+    });
+  });
+
+  describe('editComment / deleteComment', () => {
+    const authorId = new ObjectId();
+    const otherId = new ObjectId();
+    const comment = {
+      id: 'comment-1',
+      userId: authorId,
+      text: 'Original text',
+      createdAt: new Date(),
+      editedAt: null,
+    };
+    const card = { _id: new ObjectId(), comments: [comment] };
+
+    beforeEach(() => {
+      cardsCollection.findOne.mockResolvedValue(card);
+    });
+
+    describe('editComment', () => {
+      test('throws COMMENT_TEXT_REQUIRED for blank text', async () => {
+        await expect(
+          editComment(card._id.toHexString(), comment.id, {
+            userId: authorId.toHexString(),
+            text: '  ',
+          })
+        ).rejects.toMatchObject({ code: 'COMMENT_TEXT_REQUIRED', status: 400 });
+      });
+
+      test('throws COMMENT_NOT_FOUND when the comment does not exist on the card', async () => {
+        await expect(
+          editComment(card._id.toHexString(), 'missing', {
+            userId: authorId.toHexString(),
+            text: 'New text',
+          })
+        ).rejects.toMatchObject({ code: 'COMMENT_NOT_FOUND', status: 404 });
+      });
+
+      test('throws COMMENT_NOT_OWNER when the caller did not post the comment', async () => {
+        await expect(
+          editComment(card._id.toHexString(), comment.id, {
+            userId: otherId.toHexString(),
+            text: 'New text',
+          })
+        ).rejects.toMatchObject({ code: 'COMMENT_NOT_OWNER', status: 403 });
+        expect(cardsCollection.findOneAndUpdate).not.toHaveBeenCalled();
+      });
+
+      test('throws COMMENT_NOT_OWNER when the comment has no author', async () => {
+        const orphanCard = {
+          _id: new ObjectId(),
+          comments: [{ ...comment, userId: null }],
+        };
+        cardsCollection.findOne.mockResolvedValue(orphanCard);
+
+        await expect(
+          editComment(orphanCard._id.toHexString(), comment.id, {
+            userId: authorId.toHexString(),
+            text: 'New text',
+          })
+        ).rejects.toMatchObject({ code: 'COMMENT_NOT_OWNER', status: 403 });
+      });
+
+      test('updates the comment text and stamps editedAt when the author matches', async () => {
+        cardsCollection.findOneAndUpdate.mockResolvedValue(card);
+
+        await editComment(card._id.toHexString(), comment.id, {
+          userId: authorId.toHexString(),
+          text: '  New text  ',
+        });
+
+        expect(cardsCollection.findOneAndUpdate).toHaveBeenCalledWith(
+          { _id: card._id, 'comments.id': comment.id },
+          {
+            $set: expect.objectContaining({
+              'comments.$.text': 'New text',
+              'comments.$.editedAt': expect.any(Date),
+              updatedAt: expect.any(Date),
+            }),
+          },
+          { returnDocument: 'after' }
+        );
+      });
+    });
+
+    describe('deleteComment', () => {
+      test('throws COMMENT_NOT_FOUND when the comment does not exist on the card', async () => {
+        await expect(
+          deleteComment(card._id.toHexString(), 'missing', authorId.toHexString())
+        ).rejects.toMatchObject({ code: 'COMMENT_NOT_FOUND', status: 404 });
+      });
+
+      test('throws COMMENT_NOT_OWNER when the caller did not post the comment', async () => {
+        await expect(
+          deleteComment(card._id.toHexString(), comment.id, otherId.toHexString())
+        ).rejects.toMatchObject({ code: 'COMMENT_NOT_OWNER', status: 403 });
+        expect(cardsCollection.findOneAndUpdate).not.toHaveBeenCalled();
+      });
+
+      test('pulls the comment when the author matches', async () => {
+        cardsCollection.findOneAndUpdate.mockResolvedValue(card);
+
+        await deleteComment(
+          card._id.toHexString(),
+          comment.id,
+          authorId.toHexString()
+        );
+
+        expect(cardsCollection.findOneAndUpdate).toHaveBeenCalledWith(
+          { _id: card._id },
+          {
+            $pull: { comments: { id: comment.id } },
+            $set: { updatedAt: expect.any(Date) },
+          },
+          { returnDocument: 'after' }
+        );
+      });
     });
   });
 });

--- a/src/routes/famban/users/users.schema.js
+++ b/src/routes/famban/users/users.schema.js
@@ -11,6 +11,7 @@ const usersValidator = {
       _id: {},
       name: { bsonType: 'string', minLength: 1 },
       email: { bsonType: ['string', 'null'] },
+      avatarUrl: { bsonType: ['string', 'null'] },
       active: { bsonType: 'bool' },
       createdAt: { bsonType: 'date' },
       updatedAt: { bsonType: 'date' },

--- a/src/routes/famban/users/users.service.js
+++ b/src/routes/famban/users/users.service.js
@@ -41,6 +41,7 @@ async function createUser({ name, email }) {
   const doc = {
     name: trimmedName,
     email: normalizeEmail(email),
+    avatarUrl: null,
     active: true,
     createdAt: now,
     updatedAt: now,


### PR DESCRIPTION
Boards: PATCH /kanban/boards/:id now accepts an `archived` flag, mirroring the existing users.active soft-delete convention rather than introducing the API's first hard delete. GET /kanban/boards excludes archived boards by default (?includeArchived=true to see everything); direct fetch by id is unaffected. Cards are untouched by archiving.

Comments: PATCH/DELETE /kanban/cards/:id/comments/:commentId let the original author edit or delete their own comment (ownership checked against the session identity, never the request body). Editing stamps a new `editedAt` field; deleting is a genuine hard-delete, a deliberate exception to the rest of this API's preserve-history convention since a comment is a throwaway remark.

Auth: the Google ID token's `picture` claim is now captured into users.avatarUrl on every login and kept fresh if it changes, exposed via POST /auth/google, GET /auth/me, and GET /users.

Also fixes a DB startup crash: the backfills for the two new required board/comment fields ran before their validators were relaxed to allow them, so MongoDB's own additionalProperties:false rejected the backfill writes against any pre-existing database. Reordered to validate-then- backfill.